### PR TITLE
Reloads tabs using the chrome reload instead of update

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -129,7 +129,7 @@ chrome.runtime.onInstalled.addListener(function() {
     if (confirm(reloadMessage)) {
         chrome.tabs.getAllInWindow(null, function(tabs) {
             for(i = 0; i < tabs.length; i++) {
-                chrome.tabs.update(tabs[i].id, { url: tabs[i].url });
+                chrome.tabs.reload(tabs[i].id);
             }
         });
     }

--- a/src/browser_action/styles.css
+++ b/src/browser_action/styles.css
@@ -138,19 +138,19 @@ button {
 }
 
 .left {
-	margin-left: -27px;
+	margin-left: -50px;
 }
 
 .right {
-	margin-left: 25px;
+	margin-left: 50px;
 }
 
 .top {
-	margin-top: -40px;
+	margin-top: -85px;
 }
 
 .bottom {
-	margin-top: 5px;
+	margin-top: 10px;
 }
 
 .button-actions {


### PR DESCRIPTION
For some reason a few URLs weren't being affected by the update which
caused then to not initialise the process of listening for the Color
Icon events.

This commit also fixes the layout of the buttons in the pop-up